### PR TITLE
Added note about native Promise.all

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ Promise.promisifyAll(fs);
 show(fs.readFile('./index.js'));
 ```
 
+*Note:* If you're using the native `Promise.all()` function, make sure to `.bind()` it to the `Promise` before passing it into `liftp`.
+
+``` javascript
+var all = Promise.all.bind(Promise);
+var lift = liftp(all);
+```


### PR DESCRIPTION
After playing around with how native Promise implementations work with this library, I noticed that you can't call the native `Promise.all` if it isn't being invoked as a method of `Promise`. Even though a lot of people are still only relying on polyfills at the moment, I think this is important to note for anyone using this in an environment where native promises are supported.
